### PR TITLE
Overshoot fixed

### DIFF
--- a/HT_LetterSpacer.py
+++ b/HT_LetterSpacer.py
@@ -8,7 +8,7 @@
 # Basic config
 # if window = True, scripts run with a UI
 window = False
-createProofGlyph = True
+createProofGlyph = False
 
 # program
 #  Dependencies
@@ -129,6 +129,7 @@ class HTLetterspacerScript(object):
 		self.engine.LSB = self.w.LSB.get()
 		self.engine.RSB = self.w.RSB.get()
 		self.engine.width = float(self.w.width.get())
+		self.mySelection = list(set(Glyphs.font.selectedLayers))
 		self.spaceMain()
 
 		if not self.SavePreferences(self):

--- a/HT_LetterSpacer.py
+++ b/HT_LetterSpacer.py
@@ -8,7 +8,7 @@
 # Basic config
 # if window = True, scripts run with a UI
 window = False
-createProofGlyph = False
+createProofGlyph = True
 
 # program
 #  Dependencies

--- a/HT_LetterSpacer_UI.py
+++ b/HT_LetterSpacer_UI.py
@@ -1,4 +1,4 @@
-#MenuTitle: HT LetterSpacer UI
+#MenuTitle: HT LetterSpacer
 #
 # Letterspacer, an auto-spacing tool
 # Copyright (C) 2009 - 2016, The Letterspacer Project Authors
@@ -14,6 +14,7 @@ createProofGlyph = False
 #  Dependencies
 import GlyphsApp
 import vanilla
+from vanilla import dialogs
 
 import HT_LetterSpacer_lib
 reload(HT_LetterSpacer_lib)
@@ -29,7 +30,7 @@ def readConfig():
 	if os.path.isfile(confpath) == True:
 		print 'Config file exists'
 	else :
-		createFilePrompt = vanilla.dialogs.askYesNo(\
+		createFilePrompt = dialogs.askYesNo(\
 			messageText='\nMissing config file for this font.',\
 			informativeText='want to create one?')
 		if createFilePrompt == 1:

--- a/HT_LetterSpacer_lib.py
+++ b/HT_LetterSpacer_lib.py
@@ -164,7 +164,7 @@ class HTLetterpacerLib(object):
 		marginsL = [NSMakePoint(min(p.x, maxdepth), p.y) for p in marginsL]
 		marginsR = [NSMakePoint(max(p.x, mindepth), p.y) for p in marginsR]
 
-		#make overshoot work from previous version
+		#make overshoot work / under development
 		y=marginsL[0].y-paramFreq
 		while y>self.minYref:
 			marginsL.insert(0,NSMakePoint(min(p.x, maxdepth), y))

--- a/HT_LetterSpacer_lib.py
+++ b/HT_LetterSpacer_lib.py
@@ -164,7 +164,7 @@ class HTLetterpacerLib(object):
 		marginsL = [NSMakePoint(min(p.x, maxdepth), p.y) for p in marginsL]
 		marginsR = [NSMakePoint(max(p.x, mindepth), p.y) for p in marginsR]
 
-		#make overshoot work
+		#make overshoot work from previous version
 		y=marginsL[0].y-paramFreq
 		while y>self.minYref:
 			marginsL.insert(0,NSMakePoint(min(p.x, maxdepth), y))

--- a/HT_LetterSpacer_lib.py
+++ b/HT_LetterSpacer_lib.py
@@ -148,7 +148,7 @@ class HTLetterpacerLib(object):
 		lMargin, rMargin = self.setDepth(lMargin, rMargin, lExtreme, rExtreme)
 
 		# close open counterforms at 45 degrees
-		# lMargin, rMargin = self.diagonize(lMargin, rMargin)
+		lMargin, rMargin = self.diagonize(lMargin, rMargin)
 		lMargin = self.closeOpenCounters(lMargin, lExtreme)
 		rMargin = self.closeOpenCounters(rMargin, rExtreme)
 
@@ -164,17 +164,17 @@ class HTLetterpacerLib(object):
 		marginsL = [NSMakePoint(min(p.x, maxdepth), p.y) for p in marginsL]
 		marginsR = [NSMakePoint(max(p.x, mindepth), p.y) for p in marginsR]
 
-		#make overshoot work / under development
+		#add all the points at maximum depth if glyph is shorter than overshoot
 		y=marginsL[0].y-paramFreq
 		while y>self.minYref:
-			marginsL.insert(0,NSMakePoint(min(p.x, maxdepth), y))
-			marginsR.insert(0,NSMakePoint(max(p.x, mindepth), y))
+			marginsL.insert(0,NSMakePoint(maxdepth, y))
+			marginsR.insert(0,NSMakePoint(mindepth, y))
 			y-=paramFreq
 
 		y=marginsL[-1].y+paramFreq
 		while y<self.maxYref:
-			marginsL.append(NSMakePoint(min(p.x, maxdepth), y))
-			marginsR.append(NSMakePoint(max(p.x, mindepth), y))
+			marginsL.append(NSMakePoint(maxdepth, y))
+			marginsR.append(NSMakePoint(mindepth, y))
 			y+=paramFreq
 
 		# if marginsL[-1].y<(self.maxYref-paramFreq):

--- a/HT_LetterSpacer_lib.py
+++ b/HT_LetterSpacer_lib.py
@@ -88,7 +88,7 @@ def drawArea(origen, destination, puntos):
 
 	# Done drawing: close the path
 	pen.closePath()
-	print destination
+	print 'Glyph named /'+destination.name+' was created with area preview.'
 	# destination.update()
 
 
@@ -141,13 +141,14 @@ class HTLetterpacerLib(object):
 		rMargin = self.deSlant(rMargin)
 
 		# get extremes
+		# lExtreme, rExtreme = self.maxPoints(lMargin + rMargin, self.minYref, self.maxYref)
 		lExtreme, rExtreme = self.maxPoints(lMargin + rMargin, self.minYref, self.maxYref)
 
 		# set depth
 		lMargin, rMargin = self.setDepth(lMargin, rMargin, lExtreme, rExtreme)
 
 		# close open counterforms at 45 degrees
-		lMargin, rMargin = self.diagonize(lMargin, rMargin)
+		# lMargin, rMargin = self.diagonize(lMargin, rMargin)
 		lMargin = self.closeOpenCounters(lMargin, lExtreme)
 		rMargin = self.closeOpenCounters(rMargin, rExtreme)
 
@@ -162,6 +163,27 @@ class HTLetterpacerLib(object):
 		mindepth = rExtreme.x - depth
 		marginsL = [NSMakePoint(min(p.x, maxdepth), p.y) for p in marginsL]
 		marginsR = [NSMakePoint(max(p.x, mindepth), p.y) for p in marginsR]
+
+		#make overshoot work
+		y=marginsL[0].y-paramFreq
+		while y>self.minYref:
+			marginsL.insert(0,NSMakePoint(min(p.x, maxdepth), y))
+			marginsR.insert(0,NSMakePoint(max(p.x, mindepth), y))
+			y-=paramFreq
+
+		y=marginsL[-1].y+paramFreq
+		while y<self.maxYref:
+			marginsL.append(NSMakePoint(min(p.x, maxdepth), y))
+			marginsR.append(NSMakePoint(max(p.x, mindepth), y))
+			y+=paramFreq
+
+		# if marginsL[-1].y<(self.maxYref-paramFreq):
+		# 	marginsL.append(NSMakePoint(min(p.x, maxdepth), self.maxYref))
+		# 	marginsR.append(NSMakePoint(max(p.x, mindepth), self.maxYref))
+		# if marginsL[0].y>(self.minYref):
+		# 	marginsL.insert(0,NSMakePoint(min(p.x, maxdepth), self.minYref))
+		# 	marginsR.insert(0,NSMakePoint(max(p.x, mindepth), self.minYref))
+		
 		return marginsL, marginsR
 
 	# close counterforms at 45 degrees
@@ -173,24 +195,27 @@ class HTLetterpacerLib(object):
 			# left
 			actualPoint = marginsL[index]
 			nextPoint = marginsL[index + 1]
-			if nextPoint.x > (actualPoint.x + valueFreq) and nextPoint.y > actualPoint.y:
-				marginsL[index + 1].x = actualPoint.x + valueFreq
+			diff=nextPoint.y - actualPoint.y
+			if nextPoint.x > (actualPoint.x + diff) and nextPoint.y > actualPoint.y:
+				marginsL[index + 1].x = actualPoint.x + diff
 			# right
 			actualPoint = marginsR[index]
 			nextPoint = marginsR[index + 1]
-			if nextPoint.x < (actualPoint.x - valueFreq) and nextPoint.y > actualPoint.y:
-				marginsR[index + 1].x = actualPoint.x - valueFreq
+			#if nextPoint.x < (actualPoint.x - valueFreq) and nextPoint.y > actualPoint.y:
+			if nextPoint.x < (actualPoint.x - diff) and nextPoint.y > actualPoint.y:
+				marginsR[index + 1].x = actualPoint.x - diff
 
 			# left
 			actualPoint = marginsL[total - index]
 			nextPoint = marginsL[total - index - 1]
+			diff=actualPoint.y-nextPoint.y
 			if nextPoint.x > (actualPoint.x + valueFreq) and nextPoint.y < actualPoint.y:
-				marginsL[total - index - 1].x = actualPoint.x + valueFreq
+				marginsL[total - index - 1].x = actualPoint.x + diff
 			# right
 			actualPoint = marginsR[total - index]
 			nextPoint = marginsR[total - index - 1]
-			if nextPoint.x < (actualPoint.x - valueFreq) and nextPoint.y < actualPoint.y:
-				marginsR[total - index - 1].x = actualPoint.x - valueFreq
+			if nextPoint.x < (actualPoint.x - diff) and nextPoint.y < actualPoint.y:
+				marginsR[total - index - 1].x = actualPoint.x - diff
 
 		return marginsL, marginsR
 


### PR DESCRIPTION
The overshoot was not working propertly. It didn't measure above and below the end of the glyphs, because there were no depth at these areas. For example: It was impossible to obtain a difference between /n/ and /h/ or /dotlessi/ and /l/ (in sans versions)
Now the `setDepth` function was improved, and all the points between the extreme y ponts and the end of overshoot zone are added with maximum depth.
This allows to use the `paramOver` to obtain differences between different vertical stems, depending the height and the param value.