### PR TITLE
Update HT_LetterSpacer_script.py

### DIFF
--- a/HT_LetterSpacer_script.py
+++ b/HT_LetterSpacer_script.py
@@ -650,12 +650,18 @@ class HTLetterspacerScript(object):
 
 	def findException(self):
 		exception = False
+		if self.case > 0:
+			if self.case == 1:
+				self.category = Uppercase
+			elif self.case == 2:
+				self.category = Lowercase
 		for item in self.config:
 			if self.script == item[0] or item[0] == '*':
 				if self.category == item[1] or item[1] == '*':
-					if self.subCategory == item[2] or item[2] == '*' or self.case != 0:
+					if self.subCategory == item[2] or item[2] == '*':
 						if not exception or item[5] in self.glyph.name:
 							exception = item
+		print(exception, self.case, item[2])
 		return exception
 
 	def setG(self, layer):

--- a/HT_LetterSpacer_script.py
+++ b/HT_LetterSpacer_script.py
@@ -653,7 +653,7 @@ class HTLetterspacerScript(object):
 		for item in self.config:
 			if self.script == item[0] or item[0] == '*':
 				if self.category == item[1] or item[1] == '*':
-					if self.subCategory == item[2] or item[2] == '*':
+					if self.subCategory == item[2] or item[2] == '*' or self.case != 0:
 						if not exception or item[5] in self.glyph.name:
 							exception = item
 		return exception
@@ -671,6 +671,7 @@ class HTLetterspacerScript(object):
 		self.category = layer.parent.category
 		self.subCategory = layer.parent.subCategory
 		self.script = layer.parent.script
+		self.case = layer.parent.case
 		self.engine.reference = self.glyph.name
 		self.engine.factor = 1.0
 


### PR DESCRIPTION
Look at the "case" of the glyphs instead of "subCategory" to detect if the glyphs should use specific numbers from the config file to calculate the width. It allows Uppercase to get the proper spacing. Works only in Glmyphs3 since the case category is a new thing from Glyphs3.